### PR TITLE
Fix active window fall back

### DIFF
--- a/src/active-window.js
+++ b/src/active-window.js
@@ -17,7 +17,7 @@ async function getActiveAppContext() {
             lastActiveContext = url || title || 'Unknown Context';
             return lastActiveContext
         }
-        return 'lastActiveContext';
+        return lastActiveContext;
     } catch (error) {
         console.error('Error fetching active window context:', error.message);
         return lastActiveContext;


### PR DESCRIPTION
## Summary
- return cached context instead of the literal string `"lastActiveContext"`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684303fe76a883259cc102632764cda4