### PR TITLE
Fix macOS build entitlements path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mac": {
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
-      "entitlementsInherit": "build/entitlements.mac..plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "identity": "Eric Lantz (B48SRLN4E7)"
     },
     "files": [
@@ -59,3 +59,4 @@
     "node": ">=20.0.0"
   }
 }
+


### PR DESCRIPTION
## Summary
- fix typo in `entitlementsInherit` path

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843052b6e4c8325b8952e8201ccc364